### PR TITLE
feat(presupuestos)(HU-21): agregar umbral configurable de alertas y pruebas

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview",
     "seed": "node scripts/seed-transacciones.js",
     "seed:clean": "node scripts/seed-transacciones.js"

--- a/src/context/AppDataContext.jsx
+++ b/src/context/AppDataContext.jsx
@@ -10,6 +10,7 @@ import {
 } from '../services/presupuestosService'
 import { useNotificationsContext } from './NotificationsContext'
 import { useLogrosContext } from './LogrosContext'
+import { normalizarUmbralAlertaPct } from '../utils/presupuestoStatus'
 
 const AppDataContext = createContext(null)
 
@@ -31,6 +32,55 @@ function totalGastosCategoriaPeriodo(transacciones, categoriaId, mes, anio) {
       return periodo.mes === Number(mes) && periodo.anio === Number(anio)
     })
     .reduce((acum, t) => acum + Number(t.monto || 0), 0)
+}
+
+function totalGastosCategoriaPeriodoAnterior(transacciones, categoriaId, mes, anio) {
+  return totalGastosCategoriaPeriodo(transacciones, categoriaId, mes, anio)
+}
+
+async function notificarPresupuestoSiCorresponde({
+  presupuesto,
+  categoriaNombre,
+  totalAntes,
+  totalDespues,
+  mes,
+  anio,
+  preferencias,
+  registrarNotificacion
+}) {
+  if (!presupuesto || preferencias?.alertas_diarias === false) return
+
+  const limite = Number(presupuesto.monto_limite || 0)
+  const umbral = normalizarUmbralAlertaPct(presupuesto.umbral_alerta_pct)
+
+  if (totalDespues > limite && totalAntes <= limite) {
+    await registrarNotificacion({
+      tipo: 'presupuesto',
+      titulo: 'Presupuesto excedido',
+      mensaje: `Tu categoria ${categoriaNombre} supero el limite del periodo ${mes}/${anio}.`,
+      moduloOrigen: 'presupuestos',
+      rutaDestino: '/presupuestos',
+      recursoTipo: 'presupuesto',
+      recursoId: String(presupuesto.id),
+      eventKey: `presupuesto-excedido-${presupuesto.id}-${anio}-${mes}`,
+      dedupeMinutes: null
+    })
+    return
+  }
+
+  if (totalDespues >= umbral && totalAntes < umbral && totalDespues < limite) {
+    await registrarNotificacion({
+      tipo: 'presupuesto',
+      titulo: 'Presupuesto cerca del limite',
+      mensaje: `Tu categoria ${categoriaNombre} alcanzo el ${Math.round(totalDespues / limite * 100)}% del periodo ${mes}/${anio}.`,
+      moduloOrigen: 'presupuestos',
+      rutaDestino: '/presupuestos',
+      recursoTipo: 'presupuesto',
+      recursoId: String(presupuesto.id),
+      eventKey: `presupuesto-umbral-${presupuesto.id}-${anio}-${mes}`,
+      dedupeMinutes: null
+    })
+  }
 }
 
 export function AppDataProvider({ children }) {
@@ -123,24 +173,22 @@ export function AppDataProvider({ children }) {
           && Number(p.mes) === Number(mes)
           && Number(p.anio) === Number(anio)
         )
-        
-      if (presupuesto && preferencias?.alertas_diarias !== false) {
-        const totalGasto = totalGastosCategoriaPeriodo(nextTransacciones, categoriaId, mes, anio)
-        const limite = Number(presupuesto.monto_limite || 0)
-          if (totalGasto > limite) {
-          await registrarNotificacion({
-            tipo: 'presupuesto',
-            titulo: 'Presupuesto excedido',
-            mensaje: `Tu categoria ${categoriaNombre} supero el limite del periodo ${mes}/${anio}.`,
-            moduloOrigen: 'presupuestos',
-            rutaDestino: '/presupuestos',
-            recursoTipo: 'presupuesto',
-            recursoId: String(presupuesto.id),
-            eventKey: `presupuesto-excedido-${presupuesto.id}-${anio}-${mes}`,
-            dedupeMinutes: null
+
+        if (presupuesto) {
+          const totalDespues = totalGastosCategoriaPeriodo(nextTransacciones, categoriaId, mes, anio)
+          const totalAntes = totalGastosCategoriaPeriodoAnterior(transacciones, categoriaId, mes, anio)
+
+          await notificarPresupuestoSiCorresponde({
+            presupuesto,
+            categoriaNombre,
+            totalAntes,
+            totalDespues,
+            mes,
+            anio,
+            preferencias,
+            registrarNotificacion
           })
         }
-      }
       }
     } catch (notificationError) {
       console.warn('No se pudo registrar notificacion de transaccion:', notificationError)
@@ -177,7 +225,7 @@ export function AppDataProvider({ children }) {
           && Number(p.anio) === Number(periodo.anio)
         )
 
-        if (presupuesto && preferencias?.alertas_diarias !== false) {
+        if (presupuesto) {
           const totalDespues = totalGastosCategoriaPeriodo(
             nextTransacciones,
             actualizada.categoria_id,
@@ -194,20 +242,16 @@ export function AppDataProvider({ children }) {
             )
             : 0
 
-          const limite = Number(presupuesto.monto_limite || 0)
-          if (totalDespues > limite && totalAntes <= limite) {
-            await registrarNotificacion({
-              tipo: 'presupuesto',
-              titulo: 'Presupuesto excedido',
-              mensaje: `Tu categoria ${categoriaNombre} supero el limite del periodo ${periodo.mes}/${periodo.anio}.`,
-              moduloOrigen: 'presupuestos',
-              rutaDestino: '/presupuestos',
-              recursoTipo: 'presupuesto',
-              recursoId: String(presupuesto.id),
-              eventKey: `presupuesto-excedido-${presupuesto.id}-${periodo.anio}-${periodo.mes}`,
-              dedupeMinutes: null
-            })
-          }
+          await notificarPresupuestoSiCorresponde({
+            presupuesto,
+            categoriaNombre,
+            totalAntes,
+            totalDespues,
+            mes: periodo.mes,
+            anio: periodo.anio,
+            preferencias,
+            registrarNotificacion
+          })
         }
       }
     } catch (notificationError) {
@@ -222,7 +266,7 @@ export function AppDataProvider({ children }) {
     }
 
     return actualizada
-  }, [usuario?.id, categorias, presupuestos, transacciones, registrarNotificacion, evaluarYActualizarLogros])
+  }, [usuario?.id, categorias, presupuestos, transacciones, registrarNotificacion, evaluarYActualizarLogros, preferencias])
 
   const eliminarTransaccion = useCallback(async (id) => {
     if (!usuario?.id) throw new Error('Sesion invalida.')

--- a/src/hooks/usePresupuestos.js
+++ b/src/hooks/usePresupuestos.js
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useAppDataContext } from '../context/AppDataContext'
+import { calcularEstadoPresupuesto } from '../utils/presupuestoStatus'
 
 function getPeriodo(fecha) {
   const [anioTxt, mesTxt] = String(fecha || '').split('-')
@@ -19,19 +20,19 @@ function enriquecerPresupuesto(presupuesto, transacciones = []) {
     })
     .reduce((acc, t) => acc + Number(t.monto || 0), 0)
 
-  const limite = Number(presupuesto.monto_limite || 0)
-  const porcentaje = limite > 0 ? (gastado / limite) * 100 : 0
-  let estado = 'verde'
-
-  if (porcentaje >= 100) estado = 'rojo'
-  else if (porcentaje >= 80) estado = 'amarillo'
+  const estadoCalculado = calcularEstadoPresupuesto({
+    gastado,
+    monto_limite: presupuesto.monto_limite,
+    umbral_alerta_pct: presupuesto.umbral_alerta_pct
+  })
 
   return {
     ...presupuesto,
     gastado,
-    porcentaje: Math.round(porcentaje * 10) / 10,
-    estado,
-    restante: Math.max(0, limite - gastado)
+    porcentaje: estadoCalculado.porcentaje,
+    estado: estadoCalculado.estado,
+    restante: estadoCalculado.restante,
+    umbral_alerta_pct: estadoCalculado.umbral_alerta_pct
   }
 }
 

--- a/src/pages/Presupuestos.jsx
+++ b/src/pages/Presupuestos.jsx
@@ -19,10 +19,11 @@ import { usePresupuestos } from '../hooks/usePresupuestos'
 import { useCategorias } from '../hooks/useCategorias'
 import { formatMoneda } from '../utils/formatMoneda'
 import { MESES } from '../utils/constants'
-import { validatePresupuestoForm, hasErrors } from '../utils/validationHelpers'
+import { DEFAULT_UMBRAL_ALERTA_PCT } from '../utils/presupuestoStatus'
+import { validatePresupuestoUmbralForm, hasErrors } from '../utils/validationHelpers'
 
 const HOY = new Date()
-const INITIAL_FORM = { categoria_id: '', monto_limite: '' }
+const INITIAL_FORM = { categoria_id: '', monto_limite: '', umbral_alerta_pct: String(DEFAULT_UMBRAL_ALERTA_PCT) }
 
 const cx = (...classes) => classes.filter(Boolean).join(' ')
 
@@ -273,7 +274,8 @@ export default function Presupuestos() {
     setEditando(presupuesto)
     setForm({
       categoria_id: String(presupuesto.categoria_id),
-      monto_limite: String(presupuesto.monto_limite)
+      monto_limite: String(presupuesto.monto_limite),
+      umbral_alerta_pct: String(presupuesto.umbral_alerta_pct ?? DEFAULT_UMBRAL_ALERTA_PCT)
     })
     setErrors({})
     setModalOpen(true)
@@ -288,13 +290,13 @@ export default function Presupuestos() {
   const handleChange = (field, value) => {
     const next = { ...form, [field]: value }
     setForm(next)
-    setErrors(validatePresupuestoForm(next))
+    setErrors(validatePresupuestoUmbralForm(next))
   }
 
   const handleSubmit = async (e) => {
     e?.preventDefault?.()
 
-    const nextErrors = validatePresupuestoForm(form)
+    const nextErrors = validatePresupuestoUmbralForm(form)
     setErrors(nextErrors)
     if (hasErrors(nextErrors)) return
 
@@ -302,7 +304,8 @@ export default function Presupuestos() {
     try {
       const payload = {
         categoria_id: Number(form.categoria_id),
-        monto_limite: Number(form.monto_limite)
+        monto_limite: Number(form.monto_limite),
+        umbral_alerta_pct: Number(form.umbral_alerta_pct)
       }
 
       if (editando) {
@@ -502,6 +505,15 @@ export default function Presupuestos() {
                       <span className="text-[#757684] text-sm">/ {formatMoneda(p.monto_limite)} mes</span>
                     </div>
 
+                    <div className="flex items-center justify-between gap-3 mb-4 text-xs">
+                      <span className="inline-flex items-center gap-2 px-2.5 py-1 rounded-full bg-[#f3f4f5] text-[#454652] font-semibold">
+                        Alerta al {Number(p.umbral_alerta_pct ?? DEFAULT_UMBRAL_ALERTA_PCT)}%
+                      </span>
+                      <span className={cx('font-semibold', textEstado)}>
+                        {p.estado === 'rojo' ? 'Excedido' : p.estado === 'amarillo' ? 'Advertencia' : 'En rango'}
+                      </span>
+                    </div>
+
                     <div className="relative pt-1">
                       <div className={cx('overflow-hidden h-3 mb-4 text-xs flex rounded-full', barTrack)}>
                         <div className={cx('flex rounded-full transition-all duration-500', barFill)} style={{ width: `${Math.min(p.porcentaje || 0, 100)}%` }} />
@@ -597,8 +609,21 @@ export default function Presupuestos() {
           />
           {errors.monto_limite ? <p className="text-xs text-[#ba1a1a] -mt-3 ml-1">{errors.monto_limite}</p> : null}
 
+          <UiInput
+            id="pres-umbral"
+            label="Umbral de alerta (%)"
+            type="number"
+            min={1}
+            max={100}
+            step={1}
+            placeholder="Ej. 80"
+            value={form.umbral_alerta_pct}
+            onChange={(e) => handleChange('umbral_alerta_pct', e.target.value)}
+          />
+          {errors.umbral_alerta_pct ? <p className="text-xs text-[#ba1a1a] -mt-3 ml-1">{errors.umbral_alerta_pct}</p> : null}
+
           <p className="text-xs text-[#757684] bg-[#f3f4f5] rounded-xl p-3">
-            Este presupuesto aplica para <strong>{MESES[mes - 1]} {anio}</strong>
+            Este presupuesto aplica para <strong>{MESES[mes - 1]} {anio}</strong>. La advertencia se activa al alcanzar el umbral configurado y el estado rojo aparece al superar el límite.
           </p>
         </form>
       </UiModal>

--- a/src/services/presupuestosService.js
+++ b/src/services/presupuestosService.js
@@ -1,19 +1,22 @@
 import { supabase } from './supabaseClient'
+import { calcularEstadoPresupuesto } from '../utils/presupuestoStatus'
 
 // ✅ FIX: Helper extraído para reutilizar en getPresupuestos y updatePresupuesto
 function enriquecerPresupuesto(p, gastosPorCategoria) {
   const gastado = gastosPorCategoria[p.categoria_id] || 0
-  const porcentaje = p.monto_limite > 0 ? (gastado / Number(p.monto_limite)) * 100 : 0
-  let estado = 'verde'
-  if (porcentaje >= 100) estado = 'rojo'
-  else if (porcentaje >= 80) estado = 'amarillo'
+  const estadoCalculado = calcularEstadoPresupuesto({
+    gastado,
+    monto_limite: p.monto_limite,
+    umbral_alerta_pct: p.umbral_alerta_pct
+  })
 
   return {
     ...p,
     gastado,
-    porcentaje: Math.round(porcentaje * 10) / 10,
-    estado,
-    restante: Math.max(0, Number(p.monto_limite) - gastado),
+    porcentaje: estadoCalculado.porcentaje,
+    estado: estadoCalculado.estado,
+    restante: estadoCalculado.restante,
+    umbral_alerta_pct: estadoCalculado.umbral_alerta_pct,
   }
 }
 

--- a/src/utils/presupuestoStatus.js
+++ b/src/utils/presupuestoStatus.js
@@ -1,0 +1,33 @@
+export const DEFAULT_UMBRAL_ALERTA_PCT = 80
+
+export function normalizarUmbralAlertaPct(valor) {
+  const numero = Number(valor)
+
+  if (!Number.isFinite(numero)) return DEFAULT_UMBRAL_ALERTA_PCT
+
+  const entero = Math.round(numero)
+  if (entero < 1) return 1
+  if (entero > 100) return 100
+
+  return entero
+}
+
+export function calcularEstadoPresupuesto({ gastado = 0, monto_limite = 0, umbral_alerta_pct = DEFAULT_UMBRAL_ALERTA_PCT }) {
+  const limite = Number(monto_limite || 0)
+  const gastadoNormalizado = Number(gastado || 0)
+  const porcentaje = limite > 0 ? (gastadoNormalizado / limite) * 100 : 0
+  const umbral = normalizarUmbralAlertaPct(umbral_alerta_pct)
+
+  let estado = 'verde'
+  if (porcentaje >= 100) estado = 'rojo'
+  else if (porcentaje >= umbral) estado = 'amarillo'
+
+  return {
+    gastado: gastadoNormalizado,
+    monto_limite: limite,
+    umbral_alerta_pct: umbral,
+    porcentaje: Math.round(porcentaje * 10) / 10,
+    estado,
+    restante: Math.max(0, limite - gastadoNormalizado)
+  }
+}

--- a/src/utils/validationHelpers.js
+++ b/src/utils/validationHelpers.js
@@ -71,6 +71,26 @@ export function validatePresupuestoForm({ categoria_id, monto_limite }) {
   return errors
 }
 
+export function validateUmbralAlertaPct(value) {
+  if (value === null || value === undefined || value === '') {
+    return 'El umbral de alerta es obligatorio'
+  }
+
+  const num = Number(value)
+  if (Number.isNaN(num)) return 'El umbral debe ser un valor numerico'
+  if (num < 1 || num > 100) return 'El umbral debe estar entre 1 y 100'
+
+  return null
+}
+
+export function validatePresupuestoUmbralForm({ categoria_id, monto_limite, umbral_alerta_pct }) {
+  const errors = validatePresupuestoForm({ categoria_id, monto_limite })
+  const umbralErr = validateUmbralAlertaPct(umbral_alerta_pct)
+  if (umbralErr) errors.umbral_alerta_pct = umbralErr
+
+  return errors
+}
+
 export function hasErrors(errorsObj) {
   if (!errorsObj) return false
   return Object.values(errorsObj).some((v) => v)

--- a/supabase/migrations/004_budget_alert_threshold.sql
+++ b/supabase/migrations/004_budget_alert_threshold.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.presupuestos
+  ADD COLUMN IF NOT EXISTS umbral_alerta_pct integer NOT NULL DEFAULT 80;
+
+ALTER TABLE public.presupuestos
+  ADD CONSTRAINT presupuestos_umbral_alerta_pct_check
+  CHECK (umbral_alerta_pct BETWEEN 1 AND 100);

--- a/tests/presupuestoStatus.test.js
+++ b/tests/presupuestoStatus.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  calcularEstadoPresupuesto,
+  normalizarUmbralAlertaPct,
+  DEFAULT_UMBRAL_ALERTA_PCT
+} from '../src/utils/presupuestoStatus.js'
+import { validatePresupuestoUmbralForm } from '../src/utils/validationHelpers.js'
+
+test('normaliza umbral de alerta a un rango valido', () => {
+  assert.equal(normalizarUmbralAlertaPct(undefined), DEFAULT_UMBRAL_ALERTA_PCT)
+  assert.equal(normalizarUmbralAlertaPct('92'), 92)
+  assert.equal(normalizarUmbralAlertaPct(0), 1)
+  assert.equal(normalizarUmbralAlertaPct(150), 100)
+})
+
+test('calcula el estado de presupuesto usando el umbral configurable', () => {
+  const verde = calcularEstadoPresupuesto({ gastado: 70, monto_limite: 100, umbral_alerta_pct: 80 })
+  const amarillo = calcularEstadoPresupuesto({ gastado: 85, monto_limite: 100, umbral_alerta_pct: 80 })
+  const rojo = calcularEstadoPresupuesto({ gastado: 120, monto_limite: 100, umbral_alerta_pct: 80 })
+
+  assert.equal(verde.estado, 'verde')
+  assert.equal(verde.porcentaje, 70)
+  assert.equal(amarillo.estado, 'amarillo')
+  assert.equal(amarillo.porcentaje, 85)
+  assert.equal(rojo.estado, 'rojo')
+  assert.equal(rojo.restante, 0)
+})
+
+test('valida el formulario con umbral obligatorio y en rango', () => {
+  const errors = validatePresupuestoUmbralForm({
+    categoria_id: '',
+    monto_limite: '100000',
+    umbral_alerta_pct: '120'
+  })
+
+  assert.equal(Boolean(errors.categoria_id), true)
+  assert.equal(errors.umbral_alerta_pct, 'El umbral debe estar entre 1 y 100')
+})


### PR DESCRIPTION
## feat(presupuestos)(HU-21): agregar umbral configurable de alertas y pruebas

### Resumen

Se implementa un umbral configurable por presupuesto para disparar alertas de advertencia antes de llegar al límite total. Con este cambio, cada presupuesto puede definir su propio porcentaje de alerta y la aplicación usa ese valor para calcular el estado visual y las notificaciones.

---

### Cambios realizados

- Se agregó la migración para persistir `umbral_alerta_pct` en la tabla de presupuestos con valor por defecto `80`.
- Se actualizó el formulario de presupuestos para permitir editar el umbral de alerta.
- Se centralizó la lógica de estado del presupuesto en una utilidad compartida.
- Se ajustó el cálculo de colores y estados para que el amarillo dependa del umbral configurado.
- Se ampliaron las notificaciones para advertir cuando se cruza el umbral antes de exceder el límite.
- Se agregaron pruebas nativas para validar:
  - Normalización del umbral.
  - Cálculo de estado del presupuesto.
  - Validación del formulario.

---

### Impacto funcional

| Estado | Condición |
|--------|-----------|
| 🟢 Verde | Gasto por debajo del umbral configurado. |
| 🟡 Amarillo | Gasto al alcanzar o superar el umbral configurado. |
| 🔴 Rojo | Gasto superior al límite del presupuesto. |

> El comportamiento anterior de alerta por exceso se mantiene.

---

### Validación

```bash
npm test
npx eslint presupuestoStatus.js validationHelpers.js presupuestosService.js usePresupuestos.js AppDataContext.jsx Presupuestos.jsx tests/presupuestoStatus.test.js
```

---

### Notas

- El `npm run lint` global del repositorio todavía muestra errores preexistentes en archivos ajenos a este cambio.
- La migración nueva queda lista para aplicarse en el entorno de base de datos correspondiente.