### PR TITLE
chore(database): hacer idempotentes migraciones 003-005 para re-aplicación en Supabase

### DIFF
--- a/supabase/migrations/003_logros.sql
+++ b/supabase/migrations/003_logros.sql
@@ -4,7 +4,7 @@
 -- ============================================================
 
 -- TABLA: catalogo_logros (catálogo global, público, solo lectura)
-CREATE TABLE public.catalogo_logros (
+CREATE TABLE IF NOT EXISTS public.catalogo_logros (
   id text NOT NULL,
   nombre text NOT NULL,
   descripcion text NOT NULL,
@@ -19,7 +19,7 @@ CREATE TABLE public.catalogo_logros (
 );
 
 -- TABLA: progreso_logros (progreso por usuario autenticado)
-CREATE TABLE public.progreso_logros (
+CREATE TABLE IF NOT EXISTS public.progreso_logros (
   id bigserial NOT NULL,
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   logro_id text NOT NULL REFERENCES public.catalogo_logros(id) ON DELETE CASCADE,
@@ -33,29 +33,34 @@ CREATE TABLE public.progreso_logros (
 );
 
 -- Índices
-CREATE INDEX idx_progreso_logros_user_id ON public.progreso_logros (user_id);
-CREATE INDEX idx_progreso_logros_user_desbloqueado ON public.progreso_logros (user_id, desbloqueado);
-CREATE INDEX idx_catalogo_logros_categoria ON public.catalogo_logros (categoria);
-CREATE INDEX idx_catalogo_logros_activo ON public.catalogo_logros (activo);
+CREATE INDEX IF NOT EXISTS idx_progreso_logros_user_id ON public.progreso_logros (user_id);
+CREATE INDEX IF NOT EXISTS idx_progreso_logros_user_desbloqueado ON public.progreso_logros (user_id, desbloqueado);
+CREATE INDEX IF NOT EXISTS idx_catalogo_logros_categoria ON public.catalogo_logros (categoria);
+CREATE INDEX IF NOT EXISTS idx_catalogo_logros_activo ON public.catalogo_logros (activo);
 
 -- RLS para catalogo_logros: todos pueden leer, nadie modifica desde el cliente
 ALTER TABLE public.catalogo_logros ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "catalogo_logros_select_all" ON public.catalogo_logros;
 CREATE POLICY "catalogo_logros_select_all" ON public.catalogo_logros
   FOR SELECT USING (true);
 
 -- RLS para progreso_logros: cada usuario solo accede a lo suyo
 ALTER TABLE public.progreso_logros ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "progreso_logros_select" ON public.progreso_logros;
 CREATE POLICY "progreso_logros_select" ON public.progreso_logros
   FOR SELECT USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "progreso_logros_insert" ON public.progreso_logros;
 CREATE POLICY "progreso_logros_insert" ON public.progreso_logros
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "progreso_logros_update" ON public.progreso_logros;
 CREATE POLICY "progreso_logros_update" ON public.progreso_logros
   FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "progreso_logros_delete" ON public.progreso_logros;
 CREATE POLICY "progreso_logros_delete" ON public.progreso_logros
   FOR DELETE USING (auth.uid() = user_id);
 
@@ -99,4 +104,5 @@ INSERT INTO public.catalogo_logros (id, nombre, descripcion, icono, categoria, t
 
   -- 🌟 Categoría: Especial
   ('madrugador',           'Madrugador',               'Registra una transacción antes de las 7:00 AM',                  '🌅', 'especial',     'hito',       1,    24),
-  ('noctambulo',           'Noctámbulo',               'Registra una transacción después de las 11:00 PM',               '🦉', 'especial',     'hito',       1,    25);
+  ('noctambulo',           'Noctámbulo',               'Registra una transacción después de las 11:00 PM',               '🦉', 'especial',     'hito',       1,    25)
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/migrations/004_notifications_preferences.sql
+++ b/supabase/migrations/004_notifications_preferences.sql
@@ -1,5 +1,5 @@
 -- TABLA: preferencias_notificacion
-CREATE TABLE public.preferencias_notificacion (
+CREATE TABLE IF NOT EXISTS public.preferencias_notificacion (
   id bigserial NOT NULL,
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   alertas_diarias boolean NOT NULL DEFAULT true,
@@ -12,11 +12,14 @@ CREATE TABLE public.preferencias_notificacion (
 
 ALTER TABLE public.preferencias_notificacion ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "prefs_select" ON public.preferencias_notificacion;
 CREATE POLICY "prefs_select" ON public.preferencias_notificacion
   FOR SELECT USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "prefs_insert" ON public.preferencias_notificacion;
 CREATE POLICY "prefs_insert" ON public.preferencias_notificacion
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "prefs_update" ON public.preferencias_notificacion;
 CREATE POLICY "prefs_update" ON public.preferencias_notificacion
   FOR UPDATE USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);

--- a/supabase/migrations/005_academic_context.sql
+++ b/supabase/migrations/005_academic_context.sql
@@ -5,6 +5,16 @@ ALTER TABLE public.perfiles
   ADD COLUMN IF NOT EXISTS estado_academico text DEFAULT 'Activo';
 
 -- Validar valores permitidos
-ALTER TABLE public.perfiles
-  ADD CONSTRAINT perfiles_estado_academico_check
-  CHECK (estado_academico IN ('Activo', 'Pausado', 'Egresado'));
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'perfiles_estado_academico_check'
+      AND conrelid = 'public.perfiles'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE public.perfiles
+      ADD CONSTRAINT perfiles_estado_academico_check
+      CHECK (estado_academico IN (''Activo'', ''Pausado'', ''Egresado''))';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Descripción

Actualización de migraciones 003, 004 y 005 para garantizar idempotencia y evitar errores 
al re-ejecutarlas en instancias Supabase existentes o durante despliegues repetidos.

## Problema Resuelto

- **003_logros.sql**: Fallaba con error "relation already exists" al re-ejecutar
- **004_notifications_preferences.sql**: Fallaba con error "relation already exists" 
- **005_academic_context.sql**: Fallaba con error "constraint already exists"

Esto bloqueaba la capacidad de rollback, re-aplicación de migraciones y despliegues en 
múltiples ambientes (staging, producción).

## Cambios Implementados

### 003_logros.sql
- `CREATE TABLE IF NOT EXISTS` para `catalogo_logros` y `progreso_logros`
- `CREATE INDEX IF NOT EXISTS` para todos los índices
- `DROP POLICY IF EXISTS` antes de `CREATE POLICY` para políticas RLS
- `ON CONFLICT (id) DO NOTHING` en inserts de semillas para evitar duplicados

### 004_notifications_preferences.sql
- `CREATE TABLE IF NOT EXISTS` para `preferencias_notificacion`
- `DROP POLICY IF EXISTS` antes de crear políticas RLS (prefs_select, prefs_insert, prefs_update)

### 005_academic_context.sql
- Campos académicos (`semestre_actual`, `meta_grado`, `estado_academico`) con `ADD COLUMN IF NOT EXISTS`
- Constraint `perfiles_estado_academico_check` con verificación condicional usando `pg_constraint` 
  en bloque `DO $$ ... EXECUTE ... $$` para evitar duplicación

## Impacto

✅ Migraciones ahora son completamente idempotentes
✅ Permiten re-aplicación segura en cualquier momento
✅ Facilitan despliegues y rollbacks en múltiples ambientes
✅ Eliminan bloqueos por objetos DB duplicados

## Testing

- ✅ Commits y push a `origin/develop`
- ✅ Migraciones verificadas en instancia Supabase
- ✅ Todas las tablas, índices y políticas RLS presentes y funcionales

## Referencias

- Commit anterior de umbral configurable: feat(presupuestos): agregar umbral configurable de alertas
- Migrations directory: `supabase/migrations/`