### PR TITLE
feat(HU-22): meta de ahorro mensual en dashboard y presupuestos

### DIFF
--- a/src/components/ui/MetaAhorroCard.jsx
+++ b/src/components/ui/MetaAhorroCard.jsx
@@ -1,0 +1,249 @@
+import { useState, useMemo } from 'react'
+import { Target, Edit3, Check, X } from 'lucide-react'
+import toast from 'react-hot-toast'
+import { useAppDataContext } from '../../context/AppDataContext'
+
+/**
+ * Formatea un número como moneda colombiana (COP) sin decimales.
+ */
+function formatCOP(valor) {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+  }).format(valor)
+}
+
+/**
+ * Calcula el ahorro real del mes actual a partir de las transacciones.
+ * Ahorro real = ingresos del mes - gastos del mes.
+ */
+function calcularAhorroMesActual(transacciones) {
+  const ahora = new Date()
+  const mesActual = ahora.getMonth() + 1
+  const anioActual = ahora.getFullYear()
+
+  return transacciones.reduce((acum, t) => {
+    const [anioTxt, mesTxt] = String(t.fecha || '').split('-')
+    if (Number(anioTxt) !== anioActual || Number(mesTxt) !== mesActual) return acum
+    const monto = Number(t.monto || 0)
+    return t.tipo === 'ingreso' ? acum + monto : acum - monto
+  }, 0)
+}
+
+/**
+ * Determina el estado visual de la meta de ahorro:
+ * - sin_meta:    Meta == 0, aún no configurada.
+ * - cumplido:    Ahorro real >= Meta.
+ * - en_progreso: Ahorro real > 0 pero menor que la meta.
+ * - en_riesgo:   Ahorro real <= 0 (gastos >= ingresos este mes).
+ */
+function calcularEstado(metaAhorro, ahorroReal) {
+  if (metaAhorro <= 0) return 'sin_meta'
+  if (ahorroReal >= metaAhorro) return 'cumplido'
+  if (ahorroReal > 0) return 'en_progreso'
+  return 'en_riesgo'
+}
+
+const ESTADO_CONFIG = {
+  sin_meta: {
+    label: 'Sin meta configurada',
+    color: 'text-[#757684]',
+    barColor: 'bg-[#c5c5d4]',
+    bgChip: 'bg-[#f1f3f9] text-[#757684]',
+    icono: '⚪'
+  },
+  cumplido: {
+    label: '¡Meta cumplida!',
+    color: 'text-emerald-700',
+    barColor: 'bg-emerald-500',
+    bgChip: 'bg-emerald-50 text-emerald-700',
+    icono: '🟢'
+  },
+  en_progreso: {
+    label: 'En progreso',
+    color: 'text-amber-700',
+    barColor: 'bg-amber-400',
+    bgChip: 'bg-amber-50 text-amber-700',
+    icono: '🟡'
+  },
+  en_riesgo: {
+    label: 'En riesgo',
+    color: 'text-red-700',
+    barColor: 'bg-red-400',
+    bgChip: 'bg-red-50 text-red-700',
+    icono: '🔴'
+  }
+}
+
+/**
+ * MetaAhorroCard — Tarjeta reutilizable para ver y editar la meta de ahorro mensual.
+ *
+ * Se puede colocar en el Dashboard y en la vista de Presupuestos.
+ * Calcula el ahorro real del mes actual usando las transacciones del contexto.
+ */
+export default function MetaAhorroCard() {
+  const { metaAhorro, transacciones, actualizarMetaAhorro } = useAppDataContext()
+
+  const [editando, setEditando] = useState(false)
+  const [inputMeta, setInputMeta] = useState('')
+  const [guardando, setGuardando] = useState(false)
+  const [errorInput, setErrorInput] = useState('')
+
+  const ahorroReal = useMemo(() => calcularAhorroMesActual(transacciones), [transacciones])
+  const estado = calcularEstado(metaAhorro, ahorroReal)
+  const config = ESTADO_CONFIG[estado]
+
+  // Porcentaje de avance (limitado entre 0 y 100 visualmente)
+  const porcentaje = metaAhorro > 0
+    ? Math.min(100, Math.max(0, (ahorroReal / metaAhorro) * 100))
+    : 0
+
+  const mesActual = new Date().toLocaleDateString('es-CO', { month: 'long', year: 'numeric' })
+
+  // Abrir edición con el valor actual pre-rellenado
+  const abrirEdicion = () => {
+    setInputMeta(metaAhorro > 0 ? String(metaAhorro) : '')
+    setErrorInput('')
+    setEditando(true)
+  }
+
+  const cancelarEdicion = () => {
+    setEditando(false)
+    setErrorInput('')
+    setInputMeta('')
+  }
+
+  const guardarMeta = async () => {
+    const valor = Number(inputMeta)
+
+    if (inputMeta.trim() === '' || !Number.isFinite(valor) || valor < 0) {
+      setErrorInput('Ingresa un monto válido (mayor o igual a 0).')
+      return
+    }
+
+    if (valor > 999_999_999) {
+      setErrorInput('El monto no puede superar 999,999,999.')
+      return
+    }
+
+    try {
+      setGuardando(true)
+      await actualizarMetaAhorro(valor)
+      toast.success('Meta de ahorro actualizada.')
+      setEditando(false)
+      setInputMeta('')
+    } catch (err) {
+      toast.error(err?.message || 'No se pudo guardar la meta.')
+    } finally {
+      setGuardando(false)
+    }
+  }
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') guardarMeta()
+    if (e.key === 'Escape') cancelarEdicion()
+  }
+
+  return (
+    <div className="rounded-2xl border border-[#e8e9f0] bg-white shadow-sm p-6 transition-shadow hover:shadow-md">
+      {/* Encabezado */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <div className="w-9 h-9 rounded-xl bg-[#24389c]/10 flex items-center justify-center">
+            <Target className="w-5 h-5 text-[#24389c]" />
+          </div>
+          <div>
+            <p className="font-semibold text-[#191c1d] text-sm leading-tight">Meta de ahorro mensual</p>
+            <p className="text-xs text-[#757684] capitalize">{mesActual}</p>
+          </div>
+        </div>
+
+        {/* Estado chip */}
+        <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${config.bgChip}`}>
+          {config.icono} {config.label}
+        </span>
+      </div>
+
+      {/* Montos */}
+      <div className="flex items-end justify-between mb-3">
+        <div>
+          <p className="text-2xl font-extrabold text-[#191c1d] tracking-tight">
+            {formatCOP(Math.max(0, ahorroReal))}
+          </p>
+          <p className="text-xs text-[#757684] mt-0.5">
+            ahorrado {ahorroReal < 0 ? <span className="text-red-600 font-semibold">(déficit {formatCOP(Math.abs(ahorroReal))})</span> : ''}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm font-semibold text-[#454652]">
+            {metaAhorro > 0 ? formatCOP(metaAhorro) : '—'}
+          </p>
+          <p className="text-xs text-[#757684]">meta</p>
+        </div>
+      </div>
+
+      {/* Barra de progreso */}
+      <div className="h-2 bg-[#f1f3f9] rounded-full overflow-hidden mb-4">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${config.barColor}`}
+          style={{ width: `${porcentaje}%` }}
+        />
+      </div>
+
+      {/* Porcentaje */}
+      {metaAhorro > 0 && (
+        <p className={`text-xs font-semibold mb-4 ${config.color}`}>
+          {porcentaje.toFixed(1)}% de la meta alcanzado
+        </p>
+      )}
+
+      {/* Editor de meta */}
+      {editando ? (
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <input
+                type="number"
+                min="0"
+                max="999999999"
+                step="1000"
+                value={inputMeta}
+                onChange={(e) => { setInputMeta(e.target.value); setErrorInput('') }}
+                onKeyDown={handleKeyDown}
+                placeholder="Ej: 500000"
+                autoFocus
+                className="w-full border border-[#c5c5d4] rounded-xl px-4 py-2.5 text-sm font-semibold focus:outline-none focus:ring-2 focus:ring-[#24389c]/30 focus:border-[#24389c] transition-all"
+              />
+              {errorInput && <p className="text-xs text-red-600 mt-1">{errorInput}</p>}
+            </div>
+            <button
+              onClick={guardarMeta}
+              disabled={guardando}
+              className="w-10 h-10 bg-[#24389c] text-white rounded-xl flex items-center justify-center hover:bg-[#1a2b7a] transition-colors disabled:opacity-50 shrink-0"
+              title="Guardar"
+            >
+              <Check className="w-4 h-4" />
+            </button>
+            <button
+              onClick={cancelarEdicion}
+              className="w-10 h-10 border border-[#e8e9f0] text-[#757684] rounded-xl flex items-center justify-center hover:bg-[#f1f3f9] transition-colors shrink-0"
+              title="Cancelar"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={abrirEdicion}
+          className="w-full flex items-center justify-center gap-2 py-2.5 border border-[#e8e9f0] rounded-xl text-sm font-semibold text-[#454652] hover:bg-[#f1f3f9] hover:border-[#24389c]/30 hover:text-[#24389c] transition-all duration-200"
+        >
+          <Edit3 className="w-4 h-4" />
+          {metaAhorro > 0 ? 'Editar meta' : 'Configurar meta de ahorro'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/context/AppDataContext.jsx
+++ b/src/context/AppDataContext.jsx
@@ -11,6 +11,7 @@ import {
 import { useNotificationsContext } from './NotificationsContext'
 import { useLogrosContext } from './LogrosContext'
 import { normalizarUmbralAlertaPct } from '../utils/presupuestoStatus'
+import { obtenerMetaAhorro, guardarMetaAhorro } from '../services/perfilService'
 
 const AppDataContext = createContext(null)
 
@@ -91,6 +92,7 @@ export function AppDataProvider({ children }) {
   const [categorias, setCategorias] = useState([])
   const [transacciones, setTransacciones] = useState([])
   const [presupuestos, setPresupuestos] = useState([])
+  const [metaAhorro, setMetaAhorro] = useState(0)
   const [cargandoDatos, setCargandoDatos] = useState(false)
   const [errorGlobal, setErrorGlobal] = useState('')
 
@@ -98,6 +100,7 @@ export function AppDataProvider({ children }) {
     setCategorias([])
     setTransacciones([])
     setPresupuestos([])
+    setMetaAhorro(0)
     setErrorGlobal('')
     setCargandoDatos(false)
   }, [])
@@ -112,15 +115,17 @@ export function AppDataProvider({ children }) {
     setErrorGlobal('')
 
     try {
-      const [categoriasData, transaccionesData, presupuestosData] = await Promise.all([
+      const [categoriasData, transaccionesData, presupuestosData, metaAhorroData] = await Promise.all([
         listarCategorias(usuario.id),
         listarTransacciones(usuario.id),
-        listarPresupuestos(usuario.id)
+        listarPresupuestos(usuario.id),
+        obtenerMetaAhorro(usuario.id)
       ])
 
       setCategorias(categoriasData)
       setTransacciones(transaccionesData)
       setPresupuestos(presupuestosData)
+      setMetaAhorro(metaAhorroData)
     } catch (error) {
       setErrorGlobal(error.message || 'No se pudieron cargar los datos.')
     } finally {
@@ -403,6 +408,19 @@ export function AppDataProvider({ children }) {
     }
   }, [usuario?.id, presupuestos, transacciones, categorias, evaluarYActualizarLogros])
 
+  /**
+   * Actualiza la meta de ahorro mensual del usuario.
+   * Persiste el nuevo valor en Supabase y actualiza el estado local.
+   *
+   * @param {number} nuevoMonto - El nuevo monto de la meta (>= 0)
+   */
+  const actualizarMetaAhorro = useCallback(async (nuevoMonto) => {
+    if (!usuario?.id) throw new Error('Sesion invalida.')
+    const metaGuardada = await guardarMetaAhorro(usuario.id, nuevoMonto)
+    setMetaAhorro(metaGuardada)
+    return metaGuardada
+  }, [usuario?.id])
+
   const totales = useMemo(() => {
     const totalIngresos = transacciones
       .filter((t) => t.tipo === 'ingreso')
@@ -423,6 +441,7 @@ export function AppDataProvider({ children }) {
     categorias,
     transacciones,
     presupuestos,
+    metaAhorro,
     cargandoDatos,
     errorGlobal,
     totales,
@@ -437,11 +456,13 @@ export function AppDataProvider({ children }) {
     crearPresupuesto,
     actualizarPresupuesto,
     eliminarPresupuesto,
+    actualizarMetaAhorro,
     limpiarEstado
   }), [
     categorias,
     transacciones,
     presupuestos,
+    metaAhorro,
     cargandoDatos,
     errorGlobal,
     totales,
@@ -455,6 +476,7 @@ export function AppDataProvider({ children }) {
     crearPresupuesto,
     actualizarPresupuesto,
     eliminarPresupuesto,
+    actualizarMetaAhorro,
     limpiarEstado
   ])
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -19,6 +19,7 @@ import {
   CreditCard,
   Wallet
 } from 'lucide-react'
+import MetaAhorroCard from '../components/ui/MetaAhorroCard'
 
 // ─── Helpers ─────────────────────────────────────────────────────
 function formatMoney(n) {
@@ -507,6 +508,9 @@ export default function Dashboard() {
           </div>
         </div>
       </div>
+
+      {/* ─── Meta de Ahorro Mensual ─────────────────────────────────── */}
+      <MetaAhorroCard />
 
       {/* ─── Transacciones Recientes ───────────────────────────────── */}
       <div className="space-y-4">

--- a/src/pages/Presupuestos.jsx
+++ b/src/pages/Presupuestos.jsx
@@ -21,6 +21,7 @@ import { formatMoneda } from '../utils/formatMoneda'
 import { MESES } from '../utils/constants'
 import { DEFAULT_UMBRAL_ALERTA_PCT } from '../utils/presupuestoStatus'
 import { validatePresupuestoUmbralForm, hasErrors } from '../utils/validationHelpers'
+import MetaAhorroCard from '../components/ui/MetaAhorroCard'
 
 const HOY = new Date()
 const INITIAL_FORM = { categoria_id: '', monto_limite: '', umbral_alerta_pct: String(DEFAULT_UMBRAL_ALERTA_PCT) }
@@ -379,29 +380,9 @@ export default function Presupuestos() {
           </div>
         </div>
 
-        <div className="bg-[#83fba5] p-8 rounded-3xl flex flex-col justify-between">
-          <div>
-            <div className="flex justify-between items-start mb-4">
-              <PiggyBank className="w-9 h-9 text-[#005227] p-1.5 bg-white/45 rounded-lg" />
-              <span className="text-xs font-bold text-[#005227] bg-white/45 px-2 py-1 rounded-full">
-                {formatMoneda(proyeccion)}
-              </span>
-            </div>
-            <h4 className="text-[#005227] font-bold text-lg leading-tight">Meta: ahorro mensual</h4>
-            <p className="text-[#005227]/75 text-sm mt-1">Progreso de ahorro</p>
-          </div>
-          <div className="mt-6">
-            <div className="w-full h-2 bg-[#005227]/15 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-[#006d36] rounded-full transition-all duration-500"
-                style={{ width: `${Math.max(0, 100 - porcentajeGlobal)}%` }}
-              />
-            </div>
-            <div className="flex justify-between mt-2">
-              <span className="text-xs font-bold text-[#005227]">{Math.max(0, 100 - Math.round(porcentajeGlobal))}% libre</span>
-              <span className="text-xs font-medium text-[#005227]/70">{formatMoneda(totalLimite)} meta</span>
-            </div>
-          </div>
+        {/* Meta de Ahorro Mensual — reemplaza la tarjeta de ahorro estática */}
+        <div className="flex flex-col">
+          <MetaAhorroCard />
         </div>
       </section>
 

--- a/src/services/perfilService.js
+++ b/src/services/perfilService.js
@@ -57,4 +57,48 @@ export async function guardarContextoAcademico(userId, { semestre_actual, total_
   return data
 }
 
+/**
+ * Obtiene la meta de ahorro mensual del usuario.
+ * Devuelve 0 si aún no ha configurado ninguna meta.
+ */
+export async function obtenerMetaAhorro(userId) {
+  const { data, error } = await supabase
+    .from('perfiles')
+    .select('meta_ahorro_mensual')
+    .eq('id', userId)
+    .maybeSingle()
+
+  if (error) throw error
+  return Number(data?.meta_ahorro_mensual ?? 0)
+}
+
+/**
+ * Guarda la meta de ahorro mensual del usuario.
+ * Valida que el monto sea un número positivo y razonable (máx. 999,999,999).
+ *
+ * @param {string} userId - ID del usuario
+ * @param {number} monto  - Nueva meta de ahorro mensual
+ */
+export async function guardarMetaAhorro(userId, monto) {
+  const montoNum = Number(monto)
+
+  if (!Number.isFinite(montoNum) || montoNum < 0) {
+    throw new Error('La meta de ahorro debe ser un número igual o mayor a 0.')
+  }
+
+  if (montoNum > 999_999_999) {
+    throw new Error('La meta de ahorro no puede exceder 999,999,999.')
+  }
+
+  const { data, error } = await supabase
+    .from('perfiles')
+    .update({ meta_ahorro_mensual: montoNum })
+    .eq('id', userId)
+    .select('meta_ahorro_mensual')
+    .single()
+
+  if (error) throw error
+  return Number(data.meta_ahorro_mensual)
+}
+
 export { SEMESTRES_OPCIONES, MAX_SEMESTRES, ESTADOS_VALIDOS }

--- a/supabase/migrations/006_meta_ahorro.sql
+++ b/supabase/migrations/006_meta_ahorro.sql
@@ -1,0 +1,21 @@
+-- HU-22: Agregar campo meta_ahorro_mensual a la tabla perfiles
+-- Este campo almacena la meta de ahorro mensual configurada por el usuario.
+-- Un valor de 0 significa que no ha configurado ninguna meta todavía.
+
+ALTER TABLE public.perfiles
+  ADD COLUMN IF NOT EXISTS meta_ahorro_mensual numeric NOT NULL DEFAULT 0;
+
+-- Restricción: el monto debe ser no negativo
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'perfiles_meta_ahorro_mensual_check'
+      AND conrelid = 'public.perfiles'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE public.perfiles
+      ADD CONSTRAINT perfiles_meta_ahorro_mensual_check
+      CHECK (meta_ahorro_mensual >= 0)';
+  END IF;
+END
+$$;


### PR DESCRIPTION
Implementacion completa de la historia de usuario HU-22:

- supabase/migrations/006_meta_ahorro.sql: agrega columna meta_ahorro_mensual (numeric >= 0) a la tabla perfiles.

- perfilService.js: funciones obtenerMetaAhorro y guardarMetaAhorro con validaciones de rango.

- AppDataContext.jsx: estado metaAhorro, carga paralela junto a los demas datos iniciales, funcion actualizarMetaAhorro expuesta en el provider.

- MetaAhorroCard.jsx: componente reutilizable con barra de progreso animada, estados (cumplido/en progreso/en riesgo/sin meta), calculo de ahorro real del mes actual (ingresos - gastos) y formulario inline para editar la meta.

- Dashboard.jsx: integra MetaAhorroCard entre la seccion de stats y las transacciones recientes.

- Presupuestos.jsx: reemplaza la tarjeta de ahorro estatica con MetaAhorroCard, compartiendo la misma fuente de verdad.

- package.json: instala dependencia xlsx (requerida por Categorias.jsx de develop).