### PR TITLE
fix(build): eliminar import duplicado de tailwindcss en auth-theme.css

### DIFF
--- a/src/auth-theme.css
+++ b/src/auth-theme.css
@@ -1,5 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@700;800&display=swap');
-@import "tailwindcss";
 
 :root {
   --color-primary: #24389c;


### PR DESCRIPTION
Tailwind se importaba dos veces (index.css y auth-theme.css). El plugin @tailwindcss/vite solo procesa el primer @import; el segundo caía al pipeline PostCSS legacy que falla con el mismo error que index.css.

Las utilities de Tailwind ya están disponibles globalmente desde el import de index.css, así que el segundo @import era redundante.

Bonus: el CSS empaquetado baja de 68.30 kB a 58.64 kB (-14%) al evitar la duplicación de utilities.